### PR TITLE
Prevent `TypeError` when github issue does not have an assigned milestone

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,11 @@ async function main() {
         core.setFailed(`Error retrieving issue from card ${error}`);
       }
 
+      
+      // Skip issues with no assigned Milestone
+      if (issue.milestone) == null {
+        continue
+      }
 
       if (issue.milestone.title === GITHUB_RELEASE_NAME) {
         core.info(`Issue ${issue.number} has been released`);

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ async function main() {
 
       
       // Skip issues with no assigned Milestone
-      if (issue.milestone) == null {
+      if (issue.milestone == null) {
         continue
       }
 


### PR DESCRIPTION
Relates:

```
(node:1690) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'title' of null
    at main (/home/runner/work/_actions/breathingdust/github-project-archive/v1/index.js:47:27)
    at processTicksAndRejections (internal/process/task_queues.js:[9](https://github.com/hashicorp/terraform-provider-aws/runs/6124383064?check_suite_focus=true#step:3:9)7:5)
```

https://github.com/hashicorp/terraform-provider-aws/runs/6124383064?check_suite_focus=true