### PR TITLE
add pagination and fix request to list issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,68 +6,82 @@ const GITHUB_RELEASE_NAME = core.getInput('github_release_name');
 
 const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
 
-async function main() {
+const listCardsParameters = {
+  archived_state: 'not_archived',
+  column_id: GITHUB_DONE_COLUMN_ID,
+  per_page: 50,
+  mediaType: {
+    previews: [
+      'inertia'
+    ]
+  }
+}
+
+const main = async () => {
   const octokit = new Octokit();
 
-  let cards = [];
+  let issuesInMilestone = []
 
   try {
-    const response = await octokit.request('GET /projects/columns/{column_id}/cards', {
-      column_id: GITHUB_DONE_COLUMN_ID,
-      mediaType: {
-        previews: [
-          'inertia',
-        ],
-      },
-    });
-    cards = response.data;
-    core.info(`Found ${cards.length} cards in done column`);
-  } catch (error) {
-    core.setFailed('Error retrieving project cards in done column');
+    // Fetch all issues in the milestone to later compare with 
+    // issues associated with unarchived project cards.
+
+    for await(const response of octokit.paginate.iterator(
+        octokit.rest.search.issuesAndPullRequests,
+        {
+          q: `repo:${owner}/${repo}+milestone:${GITHUB_RELEASE_NAME}`,
+          per_page: 50,
+        }
+    )) {
+      issuesInMilestone.push(...response.data.map(issue => String(issue.number)))
+    }
+  } catch(error) {
+    core.setFailed(`Error fetching issues and pull requests in milestone (${GITHUB_RELEASE_NAME}): ${error}`)
   }
 
-  for (let index = 0; index < cards.length; index += 1) {
-    const card = cards[index];
-    if (card.content_url) {
-      const urlSegments = card.content_url.split('/');
-      const issueNumber = urlSegments[urlSegments.length - 1];
-      let issue = {};
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const issueReponse = await octokit.rest.issues.get({
-          owner,
-          repo,
-          issueNumber,
-        });
-        issue = issueReponse.data;
-      } catch (error) {
-        core.setFailed(`Error retrieving issue from card ${error}`);
-      }
+  core.info(`Found ${issuesInMilestone.length} issues in milestone (${GITHUB_RELEASE_NAME})`)
 
+  try {
+    // Fetch all unarchived project cards and keep only those that
+    // are associated with issues in the release milestone.
+    for await(const response of octokit.paginate.iterator(
+      octokit.projects.listCards,
+      listCardsParameters
+    )) {
+      let cardToIssueNumbers = response.data.filter(card => card.content_url != null).map(card => {
+        const urlSegments = card.content_url.split('/')
+        const issueNumber = urlSegments[urlSegments.length - 1]
+        return [card.id, issueNumber]
+      })
       
-      // Skip issues with no assigned Milestone
-      if (issue.milestone == null) {
-        continue
-      }
+      let cardsToArchive = cardToIssueNumbers.filter(tuple => issuesInMilestone.includes(tuple[1]))
 
-      if (issue.milestone.title === GITHUB_RELEASE_NAME) {
-        core.info(`Issue ${issue.number} has been released`);
-        try {
-          // eslint-disable-next-line no-await-in-loop
-          await octokit.rest.projects.updateCard({
-            card_id: card.id,
-            archived: true,
-          });
-        } catch (error) {
-          core.setFailed(`Error archiving card ${error}`);
+      if (cardsToArchive.length > 0) {
+        core.info(`Found ${cardsToArchive.length} cards in milestone to archive`)
+        
+        for (let i = 0; i < cardsToArchive.length; i++) {
+          let cardId = cardsToArchive[i][0]
+          
+          try {
+            const resp = await octokit.projects.updateCard({
+              card_id: cardId,
+              archived: true,
+            });
+
+            if (resp.status == 200) {
+              core.info(`Successfully archived project card: ${cardId}`)
+            } else {
+              core.info(`Request to archive project card (${cardId}) returned status: ${resp.status} `)
+            }
+          } catch (error) {
+              core.setFailed(`Error archiving project card (${cardId}): ${error}`);
+          }
         }
       }
     }
+  } catch(error) {
+    core.setFailed(`Error attempting to archive project cards in milestone (${GITHUB_RELEASE_NAME}): ${error}`);
   }
 }
 
-try {
-  main();
-} catch (error) {
-  core.setFailed(error);
-}
+main()


### PR DESCRIPTION
### Description

* This PR attempts to fix the `Not Found` error received when retrieving github issues with `issueNumber` as the  API expects  named parameters like {`issue_id: issueNumber`} instead.
* Additionally, pagination is added to methods that retrieve issues and cards outside the set default
* I've tested this locally using `@octokit/rest` instead but didn't try actually archiving cards...will leave the action to do it for us and see 🤞 

Reference:
* https://github.com/hashicorp/terraform-provider-aws/runs/6134082200?check_suite_focus=true